### PR TITLE
Fix delay_ms for big delays with high system clock

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -21,8 +21,12 @@ impl Delay {
 }
 
 impl DelayMs<u32> for Delay {
-    fn delay_ms(&mut self, ms: u32) {
-        // TODO: may overflow
+    fn delay_ms(&mut self, mut ms: u32) {
+        let max_ms = (1<<24) / self.clock_speed_mhz / 1000;
+        while ms > max_ms {
+            self.delay_us(max_ms * 1_000);
+            ms -= max_ms;
+        }
         self.delay_us(ms * 1_000);
     }
 }


### PR DESCRIPTION
The timer is a 24bit timer and would assert when trying to sleep more than 349ms with a 48MHz clock.